### PR TITLE
Targeted clear rbcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ add_computer computer [password] - Adds a new computer to the domain with the sp
 add_user new_user [parent] - Creates a new user.
 add_user_to_group user group - Adds a user to a group.
 change_password user [password] - Attempt to change a given user's password. Requires LDAPS.
-clear_rbcd target - Clear the resource based constrained delegation configuration information.
+clear_rbcd target grantee - Clear the resource based constrained delegation configuration information.
 disable_account user - Disable the user's account.
 enable_account user - Enable the user's account.
 dump - Dumps the domain.

--- a/ldap_shell/impacket_ldap_shell.py
+++ b/ldap_shell/impacket_ldap_shell.py
@@ -16,7 +16,6 @@ from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.formatters.formatters import format_sid
 
 from ldap_shell import ldaptypes
-import pdb
 
 log = logging.getLogger('ldap-shell.shell')
 
@@ -398,7 +397,6 @@ class LdapShell(cmd.Cmd):
 
         sd['Dacl'].aces = upd_sd
         del upd_sd
-        
         self.client.modify(target.entry_dn,
                            {'msDS-AllowedToActOnBehalfOfOtherIdentity': [ldap3.MODIFY_REPLACE, [sd.getData()]]})
         


### PR DESCRIPTION
Modified do_clear_rbcd function in order to remove only added during engagement entry instead of full content of msDS-AllowedToActOnBehalfOfOtherIdentity property

Please, check carefully if merge 